### PR TITLE
Header/Footer style changed to not affect all QGroupBox Widgets

### DIFF
--- a/Common/FooterWidget.cpp
+++ b/Common/FooterWidget.cpp
@@ -56,7 +56,6 @@ FooterWidget::FooterWidget(QWidget *parent)
   QPixmap newPixmap = pixmap.scaled(QSize(40,40),  Qt::KeepAspectRatio);
   nsfLogo->setPixmap(newPixmap);
   nsfLogo->setMask(newPixmap.mask());
-  nsfLogo->show();
   
   // putting some text in another
   QLabel *nsfText = new QLabel();
@@ -68,7 +67,6 @@ FooterWidget::FooterWidget(QWidget *parent)
   QPixmap pixmap2(":/imagesCommon/sim_logo_footer.png");
   QPixmap newPixmap2 = pixmap2;
   simLogo->setPixmap(newPixmap2);
-  simLogo->show();
   
   // adding both to a layout
   QHBoxLayout *layout = new QHBoxLayout;

--- a/Common/style.qss
+++ b/Common/style.qss
@@ -69,7 +69,7 @@ QLineEdit {
 * ======= <HEADER AND FOOTER> =======
 */
 
-QGroupBox {
+FooterWidget, HeaderWidget {
     background-color: #B0BEC5;
     height: 30px;
     border-radius: 5px;


### PR DESCRIPTION
Current style sheet will set all QGroupBox Widgets to look like header and footer, this change make the style specific to HeaderWidget and FooterWidget only