### PR TITLE
Fixed error for inheritance graphs in documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
   apt:
     packages:
       - doxygen
+      - doxygen-doc
+      - doxygen-latex
+      - doxygen-gui
+      - graphviz
 
 script:
   - doxygen Doxyfile


### PR DESCRIPTION
Updated Travis configuration to include packages to generate inheritance graphs in Doxygen.