### PR TITLE
Update to PCEInputWidget set number of tasks

### DIFF
--- a/Workflow/UQ/PCEInputWidget.cpp
+++ b/Workflow/UQ/PCEInputWidget.cpp
@@ -134,7 +134,7 @@ bool PCEInputWidget::inputFromJSON(QJsonObject &jsonObject)
 
 int PCEInputWidget::getNumberTasks()
 {
-    return 1;
+  return level->text().toInt();
 }
 
 void PCEInputWidget::trainingDataMethodChanged(int method) {


### PR DESCRIPTION
Set `PCEInputWidget` to set number of tasks equal to order of quadrature.