### PR TITLE
Fix crash where remote thread was calling a QWidget directly. 

### DIFF
--- a/Common/Utils/PythonProgressDialog.h
+++ b/Common/Utils/PythonProgressDialog.h
@@ -2,6 +2,7 @@
 #define PYTHONPROGRESSDIALOG_H
 
 #include <QDialog>
+#include <QMutex>
 
 class QPlainTextEdit;
 class QProgressBar;
@@ -26,12 +27,13 @@ public:
 
     void clear(void);
 
-    void showDialog(bool visible);
+    void setVisibility(bool visible);
 
     void setProgressBarValue(const int val);
     void setProgressBarRange(const int start,const int end);
 
     void hideAfterElapsedTime(int sec);
+
 
 public slots:
     void showProgressBar(void);
@@ -49,6 +51,9 @@ private:
     QString cleanUpText(const QString text);
 
     QProgressBar* progressBar;
+
+    QMutex* mutex;
+
 };
 
 #endif // PYTHONPROGRESSDIALOG_H

--- a/Workflow/ANALYSIS/InputWidgetOpenSeesAnalysis.h
+++ b/Workflow/ANALYSIS/InputWidgetOpenSeesAnalysis.h
@@ -62,7 +62,7 @@ public:
 signals:
 
 public slots:
-   void clear(void);
+   void clear(void) override;
    void chooseFileName(void);
    void dampingEditingFinished();
    void toleranceEditingFinished();

--- a/Workflow/EXECUTION/AgaveCurl.cpp
+++ b/Workflow/EXECUTION/AgaveCurl.cpp
@@ -66,7 +66,6 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QDialog>
 #include <QStandardPaths>
 #include <QDir>
-#include <Utils/PythonProgressDialog.h>
 
 using namespace std;
 
@@ -345,12 +344,10 @@ AgaveCurl::login(QString uname, QString upassword)
                 } else {
                     emit statusMessage("Login SUCCESS");
                     emit closeDialog();
-                    PythonProgressDialog::getInstance()->hideAfterElapsedTime(0);
                 }
             } else {
                 emit statusMessage("Login SUCCESS");
                 emit closeDialog();
-                PythonProgressDialog::getInstance()->hideAfterElapsedTime(0);
             }
 
             return true;
@@ -412,8 +409,6 @@ AgaveCurl::logout()
     emit statusMessage("Logout SUCCESS");
 
     emit closeDialog();
-    PythonProgressDialog::getInstance()->hideAfterElapsedTime(0);
-
     loggedInFlag = false;
 
     return true;

--- a/Workflow/WORKFLOW/MainWindowWorkflowApp.cpp
+++ b/Workflow/WORKFLOW/MainWindowWorkflowApp.cpp
@@ -189,6 +189,7 @@ MainWindowWorkflowApp::MainWindowWorkflowApp(QString appName, WorkflowAppWidget 
     // allow remote interface to send error and status messages
     connect(theRemoteInterface,SIGNAL(errorMessage(QString)),inputWidget,SLOT(errorMessage(QString)));
     connect(theRemoteInterface,SIGNAL(statusMessage(QString)),inputWidget,SLOT(statusMessage(QString)));
+    connect(theRemoteInterface,SIGNAL(closeDialog()),inputWidget,SLOT(closeDialog()));
 
     connect(this,SIGNAL(sendErrorMessage(QString)),inputWidget,SLOT(errorMessage(QString)));
     connect(this,SIGNAL(sendStatusMessage(QString)),inputWidget,SLOT(statusMessage(QString)));
@@ -439,7 +440,7 @@ void MainWindowWorkflowApp::loadFile(const QString &fileName)
     // check file exists & set apps current dir of it does
     QFileInfo fileInfo(fileName);
     if (!fileInfo.exists()){
-        QString msg = QString("File foes not exist: ") + fileName;
+        QString msg = QString("File does not exist: ") + fileName;
         emit sendErrorMessage(msg);
         errorLabel->setText(msg);
         return;
@@ -573,7 +574,7 @@ void MainWindowWorkflowApp::createActions() {
         foreach (const QJsonValue & example, examples) {
             QJsonObject exampleObj = example.toObject();
             QString name = exampleObj["name"].toString();
-            QString inputFile = exampleObj["InputFile"].toString();
+            QString inputFile = exampleObj["inputFile"].toString();
             QString description = exampleObj["description"].toString();
             auto action = exampleMenu->addAction(name, this, &MainWindowWorkflowApp::loadExamples);
             action->setProperty("Name",name);

--- a/Workflow/WORKFLOW/WorkflowAppWidget.cpp
+++ b/Workflow/WORKFLOW/WorkflowAppWidget.cpp
@@ -14,7 +14,7 @@ WorkflowAppWidget::WorkflowAppWidget(RemoteService *theService, QWidget *parent)
 {
     this->setContentsMargins(0,0,0,0);
 
-    progressDialog = PythonProgressDialog::getInstance(parent);
+    progressDialog = PythonProgressDialog::getInstance(this);
 }
 
 WorkflowAppWidget::~WorkflowAppWidget()
@@ -25,7 +25,7 @@ WorkflowAppWidget::~WorkflowAppWidget()
 
 void WorkflowAppWidget::showOutputDialog(void)
 {
-    progressDialog->showDialog(true);
+    progressDialog->setVisibility(true);
 }
 
 
@@ -53,6 +53,12 @@ WorkflowAppWidget::errorMessage(const QString msg){
     qDebug() << "WorkflowAppWidget::errorMessage" << msg;
     progressDialog->appendErrorMessage(msg);
     emit sendErrorMessage(msg);
+}
+
+
+void
+WorkflowAppWidget::closeDialog(){
+    progressDialog->setVisibility(false);
 }
 
 

--- a/Workflow/WORKFLOW/WorkflowAppWidget.h
+++ b/Workflow/WORKFLOW/WorkflowAppWidget.h
@@ -89,6 +89,7 @@ public slots:
     virtual void statusMessage(QString message);
     virtual void errorMessage(QString message);
     virtual void fatalMessage(QString message);
+    virtual void closeDialog();
     virtual void runComplete();
 
 protected:


### PR DESCRIPTION
The GUI classes, notably QWidget and all its subclasses, are not reentrant. They can only be accessed from the main thread. Solution is to use signals/slots for communication between main thread and any sub-threads.