### PR TITLE
Minor fixes for quoFEM

### DIFF
--- a/Common/Utils/PythonProgressDialog.cpp
+++ b/Common/Utils/PythonProgressDialog.cpp
@@ -103,6 +103,8 @@ void PythonProgressDialog::appendText(const QString text)
 {
     mutex->lock();
 
+    progressTextEdit->moveCursor(QTextCursor::End);
+
     if (theInstance == 0)
         theInstance = new PythonProgressDialog(0);
 
@@ -117,8 +119,7 @@ void PythonProgressDialog::appendText(const QString text)
 
     progressTextEdit->insertPlainText(cleanText);
 
-    progressTextEdit->moveCursor(QTextCursor::End);
-
+    //progressTextEdit->moveCursor(QTextCursor::End); // moved it to the front -sy
     //qDebug()<<cleanText;
 
     mutex->unlock();

--- a/RandomVariables/BetaDistribution.cpp
+++ b/RandomVariables/BetaDistribution.cpp
@@ -110,9 +110,16 @@ BetaDistribution::BetaDistribution(QString inpType, QWidget *parent) :RandomVari
         mainLayout->setColumnStretch(4,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     thePlot = new SimCenterGraphPlot(QString("x"),QString("Probability Density Function"),500, 500);
@@ -319,5 +326,9 @@ BetaDistribution::updateDistributionPlot() {
             thePlot->clear();
             thePlot->addLine(x,y);
             thePlot->addLine(x1,y1);
+        }
+
+        if (aa>bb) {
+            thePlot->clear();
         }
 }

--- a/RandomVariables/ChiSquaredDistribution.cpp
+++ b/RandomVariables/ChiSquaredDistribution.cpp
@@ -89,9 +89,16 @@ ChiSquaredDistribution::ChiSquaredDistribution(QString inpType, QWidget *parent)
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(2,1);

--- a/RandomVariables/DiscreteDistribution.cpp
+++ b/RandomVariables/DiscreteDistribution.cpp
@@ -110,9 +110,16 @@ DiscreteDistribution::DiscreteDistribution(QString inpType, QWidget *parent) :Ra
         mainLayout->addWidget(chooseFileButton, 1, 1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(3,1);

--- a/RandomVariables/ExponentialDistribution.cpp
+++ b/RandomVariables/ExponentialDistribution.cpp
@@ -87,9 +87,16 @@ ExponentialDistribution::ExponentialDistribution(QString inpType, QWidget *paren
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(2,1);

--- a/RandomVariables/GammaDistribution.cpp
+++ b/RandomVariables/GammaDistribution.cpp
@@ -92,9 +92,16 @@ GammaDistribution::GammaDistribution(QString inpType, QWidget *parent) :RandomVa
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(3,1);

--- a/RandomVariables/GumbelDistribution.cpp
+++ b/RandomVariables/GumbelDistribution.cpp
@@ -91,9 +91,16 @@ GumbelDistribution::GumbelDistribution(QString inpType, QWidget *parent) :Random
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(3,1);

--- a/RandomVariables/LognormalDistribution.cpp
+++ b/RandomVariables/LognormalDistribution.cpp
@@ -91,9 +91,16 @@ LognormalDistribution::LognormalDistribution(QString inpType, QWidget *parent) :
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(3,1);
@@ -244,4 +251,7 @@ LognormalDistribution::updateDistributionPlot() {
             thePlot->addLine(x,y);
         }
 
+       if ((st <= 0.0)|| (me <= 0)) {
+            thePlot->clear();
+        }
 }

--- a/RandomVariables/NormalDistribution.cpp
+++ b/RandomVariables/NormalDistribution.cpp
@@ -83,9 +83,16 @@ NormalDistribution::NormalDistribution(QString inpType, QWidget *parent) :Random
         mainLayout->setColumnStretch(2,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     thePlot = new SimCenterGraphPlot(QString("x"),QString("Probability Density Function"),500, 500);
@@ -223,7 +230,10 @@ NormalDistribution::updateDistributionPlot() {
     if ((this->inpty)==QString("Parameters") || (this->inpty)==QString("Moments")) {
         double me = mean->text().toDouble();
         double st =standardDev->text().toDouble();
-        if (st > 0.0) {
+        if (st < 0.0) {
+            st = 0;
+            me = 0;
+        }
             double min = me - 5*st;
             double max = me + 5*st;
             QVector<double> x(100);
@@ -235,6 +245,5 @@ NormalDistribution::updateDistributionPlot() {
             }
             thePlot->clear();
             thePlot->addLine(x,y);
-        }
     }
 }

--- a/RandomVariables/RandomVariablesContainer.cpp
+++ b/RandomVariables/RandomVariablesContainer.cpp
@@ -120,18 +120,18 @@ void
 RandomVariablesContainer::addUniformRVs(QStringList &varNamesAndValues)
 {
     // remove existing RVs
-    auto theRVs = this->theRandomVariables;
-    int numEDPs = theRVs.size();
-    for (int i = numEDPs-1; i >= 0; i--) {
-        RandomVariable *theRV = theRVs.at(i);
-        theRV->close();
-        rvLayout->removeWidget(theRV);
-        theRVs.remove(i);
-        randomVariableNames.removeAt(i);
-        theRandomVariables.remove(i);
-        theRV->setParent(0);
-        delete theRV;
-    }
+//    auto theRVs = this->theRandomVariables;
+//    int numEDPs = theRVs.size();
+//    for (int i = numEDPs-1; i >= 0; i--) {
+//        RandomVariable *theRV = theRVs.at(i);
+//        theRV->close();
+//        rvLayout->removeWidget(theRV);
+//        theRVs.remove(i);
+//        randomVariableNames.removeAt(i);
+//        theRandomVariables.remove(i);
+//        theRV->setParent(0);
+//        delete theRV;
+//    }
 
     int numVar = varNamesAndValues.count();
     for (int i=0; i<numVar; i+= 2) {

--- a/RandomVariables/TruncatedExponentialDistribution.cpp
+++ b/RandomVariables/TruncatedExponentialDistribution.cpp
@@ -103,9 +103,16 @@ TruncatedExponentialDistribution::TruncatedExponentialDistribution(QString inpTy
         mainLayout->addWidget(chooseFileButton, 1,3);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
 

--- a/RandomVariables/UniformDistribution.cpp
+++ b/RandomVariables/UniformDistribution.cpp
@@ -92,9 +92,16 @@ UniformDistribution::UniformDistribution(QString inpType, QWidget *parent) :Rand
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
-        });
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
+              });
     }
 
     mainLayout->setColumnStretch(3,1);

--- a/RandomVariables/WeibullDistribution.cpp
+++ b/RandomVariables/WeibullDistribution.cpp
@@ -93,8 +93,15 @@ WeibullDistribution::WeibullDistribution(QString inpType, QWidget *parent) :Rand
         mainLayout->addWidget(chooseFileButton, 1,1);
 
         // Action
+//        connect(chooseFileButton, &QPushButton::clicked, this, [=](){
+//                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+//        });
+
         connect(chooseFileButton, &QPushButton::clicked, this, [=](){
-                dataDir->setText(QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*.*)"));
+                  QString fileName = QFileDialog::getOpenFileName(this,tr("Open File"),"", "All files (*)");
+                  if (!fileName.isEmpty()) {
+                      dataDir->setText(fileName);
+                  }
         });
     }
 


### PR DESCRIPTION
- SimCenterUQ - RV tab - preventing path strings from being deleted when "choose" is clicked and nothing is selected (for dataset inputs)
- Fixing an issue in displaying status/error messages (found in quoFEM)