### PR TITLE
Migrating from Google Universal Analytics to Google Analytics 4

### DIFF
--- a/Common/GoogleAnalytics.cpp
+++ b/Common/GoogleAnalytics.cpp
@@ -1,4 +1,8 @@
 #include "GoogleAnalytics.h"
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QJsonDocument>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>
 #include <QHostInfo>
@@ -7,35 +11,30 @@
 
 namespace GoogleAnalytics {
 
-void ReportStart()
-{
-    Report("Start");
-}
-
 void ReportLocalRun()
 {
-    Report("Local", "Simulation");
+    Report("Simulation", "Local");
 }
 
 void ReportDesignSafeRun()
 {
-    Report("DesignSafe", "Simulation");
+    Report("Simulation", "DesignSafe");
 }
 
 void ReportAppUsage(QString appName)
 {
-    Report("application", appName);
+    Report("Application", appName);
 }  
 
 void StartSession()
 {
-    Report("Start", "Session", SessionControl::Start);
+    Report("Session", "Start");
 
 }
 
 void EndSession()
 {
-    Report("End", "Session", SessionControl::End);
+    Report("Session", "End");
 }
 
 //TODO: This code may need to be refactored and shared in SimCenterCommon
@@ -51,52 +50,112 @@ QUuid GetCommonClientId()
     return clientIdSetting.toUuid();
 }
 
-void SetTrackingId(QString atrackingId)
+void SetMeasurementId(QString measurementId)
 {
-    trackingId = atrackingId;
+    _measurementId = measurementId;
 }
 
-void Report(QString eventAction, QString category, SessionControl sessionControl)
+void SetAPISecret(QString api_secret)
+{
+    _api_secret = api_secret;
+}
+
+void CreateSessionId()
+{
+    _sessionId = QUuid::createUuid();
+}
+
+void sendReport();
+
+
+void Report(QString eventCategory, QString eventName)
 {
     // no tracking if no tracking ID set
-    if (trackingId.isEmpty())
+    if (_measurementId.isEmpty() || _api_secret.isEmpty())
         return;
 
-    QNetworkRequest request;
-    QUrl host("http://www.google-analytics.com/collect");
-    request.setUrl(host);
-    request.setHeader(QNetworkRequest::ContentTypeHeader,
-                      "application/x-www-form-urlencoded");
-
-    // setup parameters of request
-    QString requestParams;
-    QUuid clientId = GetCommonClientId();
-    requestParams += "v=1"; // version of protocol
-    requestParams += "&tid=" + trackingId; // Google Analytics account
-    requestParams += "&cid=" + clientId.toString(); // unique user identifier
-    requestParams += "&t=event";  // hit type = event others pageview, exception
-    requestParams += "&an=" + QCoreApplication::applicationName();   // app name
-    requestParams += "&av=" + QCoreApplication::applicationVersion(); // app version
-    requestParams += "&ec=" + category;   // event category
-    requestParams += "&ea=" + eventAction; // event action
-    requestParams += "&aip=1"; // Anonymize IP
-    requestParams += "&ds=app"; // DataSource
-
-    if(sessionControl == SessionControl::Start) {
-        requestParams += "&sc=start"; // Start Session
-    }
-    else if (sessionControl == SessionControl::End){
-        requestParams += "&sc=end"; // End Session
-    }
-    // send request via post method
-    QNetworkReply* reply = networkManager.post(request, requestParams.toStdString().c_str());
-
-    //If this a session end, we have to wait for the network request to finish
-    if (sessionControl == SessionControl::End)
+    //build JSON payload
+    //ex:
+    /*
     {
-        QEventLoop loop;
-        QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-        loop.exec();
+        "client_id": UUID,
+        "events": [{
+            "name": eventCategory,
+            "params": {
+                "type": "eventName",
+                "engagement_time_msec": 100 (default),
+                "session_id": UUID,
+                "os": "computer os"
+            }
+        }]
+    }
+    */
+
+    // JSON Root
+    QJsonObject jsonData = QJsonObject();
+
+    // Defining Client Id
+    QString clientId = GetCommonClientId().toString();
+    jsonData["client_id"] = clientId;
+
+    // Defining the Event
+    QJsonObject event = QJsonObject();
+    event["name"] = eventCategory;
+
+    // Defining the Event Parameters
+    // In order for user activity to display in standard reports like Realtime, engagement_time_msec and session_id must be supplied as part of the params for an event.
+    QJsonObject eventParams = QJsonObject();
+    eventParams["type"] = eventName;
+    eventParams["engagement_time_msec"] = 100;
+    eventParams["session_id"] = _sessionId.toString();
+    #ifdef Q_OS_WIN
+        eventParams["os"] = "Windows";
+    #endif
+    #ifdef Q_OS_LINUX
+        eventParams["os"] = "Linux";
+    #endif
+    #ifdef Q_OS_MAC
+        eventParams["os"] = "MAC";
+    #endif
+
+    // Attach Parameters to the Event
+    event["params"] = eventParams;
+
+    // Add the Event to the Events Array (as GA4 expects)
+    QJsonArray events = QJsonArray();
+    events += event;
+    jsonData["events"] = events;
+
+    // Sending the request
+    // Convert JSON object into string
+    QByteArray requestJson = QJsonDocument(jsonData).toJson();
+
+    // Create the Request
+    QNetworkRequest garequest = QNetworkRequest();
+    garequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json; charset=utf-8");
+
+    // Create and set the Google Analytics 4 Measurement Protocol URL
+    QString requestUrl = "https://www.google-analytics.com/mp/collect?measurement_id=%1&api_secret=%2";
+    requestUrl = requestUrl.arg(_measurementId).arg(_api_secret);
+    garequest.setUrl(QUrl(requestUrl));
+
+    // create custom temporary event loop on stack
+    QEventLoop eventLoop;
+
+    // "quit()" the event-loop, when the network request "finished()"
+    QObject::connect(&networkManager, SIGNAL(finished(QNetworkReply*)), &eventLoop, SLOT(quit()));
+
+    // the HTTP request
+    QNetworkReply *reply = networkManager.post(garequest, requestJson);
+    eventLoop.exec(); // blocks stack until "finished()" has been called
+    if (reply->error() == QNetworkReply::NoError) {
+        //success
+        delete reply;
+    }
+    else {
+        //failure
+        qDebug() << "Google Analytics request failure: " << reply->errorString();
+        delete reply;
     }
 }
 

--- a/Common/GoogleAnalytics.h
+++ b/Common/GoogleAnalytics.h
@@ -6,7 +6,7 @@
 namespace GoogleAnalytics {
 enum SessionControl {Start, End, None};
 
-void Report(QString eventAction, QString category = "Action", SessionControl sessionControl = None);
+void Report(QString eventCategory, QString eventName = "Action");
 void ReportStart();
 void ReportLocalRun();
 void ReportDesignSafeRun();
@@ -14,9 +14,13 @@ void ReportAppUsage(QString appName);
 void StartSession();
 void EndSession();
 QUuid GetCommonClientId();
-void SetTrackingId(QString trackingId);
+void SetMeasurementId(QString measurementId);
+void SetAPISecret(QString api_secret);
+void CreateSessionId();
 
-static QString trackingId = "";
+static QString _measurementId = "";
 static QNetworkAccessManager networkManager;
+static QUuid _sessionId;
+static QString _api_secret;
 }
 #endif // GOOGLEANALYTICS_H

--- a/Common/SimCenterAppSelection.cpp
+++ b/Common/SimCenterAppSelection.cpp
@@ -336,7 +336,7 @@ bool SimCenterAppSelection::inputAppDataFromJSON(QJsonObject &jsonObject)
 bool SimCenterAppSelection::copyFiles(QString &destDir)
 {
   if (theCurrentSelection != NULL) {
-    QString textForAnalytics = jsonKeyword + QString("-") + theApplicationNames.at(currentIndex);
+        QString textForAnalytics = jsonKeyword.replace("-", "_") + QString("_") + theApplicationNames.at(currentIndex);
     GoogleAnalytics::ReportAppUsage(textForAnalytics);    
     return theCurrentSelection->copyFiles(destDir);
   } else

--- a/Workflow/UQ/customUQ/UQ_JsonEngine.cpp
+++ b/Workflow/UQ/customUQ/UQ_JsonEngine.cpp
@@ -162,7 +162,7 @@ bool
 UQ_JsonEngine::copyFiles(QString &fileDir) {
   
     Q_UNUSED(fileDir);
-    QString googleString=QString("UQ-CustomUQ-") + this->getMethodName();
+    QString googleString=QString("UQ_CustomUQ_") + this->getMethodName();
     GoogleAnalytics::ReportAppUsage(googleString);
 
     return true;

--- a/Workflow/UQ/dakota/DakotaEngine.cpp
+++ b/Workflow/UQ/dakota/DakotaEngine.cpp
@@ -325,7 +325,7 @@ DakotaEngine::fixMethod(QString Methodname) {
 }
 bool
 DakotaEngine::copyFiles(QString &fileDir) {
-    QString googleString=QString("UQ-DAKOTA-") + this->getMethodName();
+    QString googleString=QString("UQ_DAKOTA_") + this->getMethodName();
     GoogleAnalytics::ReportAppUsage(googleString);
 
     return theCurrentEngine->copyFiles(fileDir);

--- a/Workflow/UQ/simcenterUQ/SimCenterUQEngine.cpp
+++ b/Workflow/UQ/simcenterUQ/SimCenterUQEngine.cpp
@@ -298,7 +298,7 @@ SimCenterUQEngine::fixMethod(QString Methodname) {
 
 bool
 SimCenterUQEngine::copyFiles(QString &fileDir) {
-    QString googleString=QString("UQ-SimCenterUQ-") + this->getMethodName();
+    QString googleString=QString("UQ_SimCenterUQ_") + this->getMethodName();
     GoogleAnalytics::ReportAppUsage(googleString);
 
     return theCurrentEngine->copyFiles(fileDir);

--- a/Workflow/UQ/ucsd/UCSD_Engine.cpp
+++ b/Workflow/UQ/ucsd/UCSD_Engine.cpp
@@ -230,7 +230,7 @@ UCSD_Engine::fixMethod(QString Methodname) {
 
 bool
 UCSD_Engine::copyFiles(QString &fileName) {
-    QString googleString=QString("UQ-UCSD-") + this->getMethodName();
+    QString googleString=QString("UQ_UCSD_") + this->getMethodName();
     GoogleAnalytics::ReportAppUsage(googleString);
     return theCurrentMethod->copyFiles(fileName);
 }


### PR DESCRIPTION
UA will stop reporting on July 1st 2023. This implementation will send data using the updated Measurement Protocol to GA4.

*note: All main functions in other tools will need to be updated to supply the correct measurement id and API secrets for those applications. In these functions the QApplication must be started before the first report.



