### PR TITLE
GA4 explicit event names

### DIFF
--- a/Common/GoogleAnalytics.cpp
+++ b/Common/GoogleAnalytics.cpp
@@ -13,27 +13,32 @@ namespace GoogleAnalytics {
 
 void ReportLocalRun()
 {
+    Report("SimulationLocal", "");
     Report("Simulation", "Local");
 }
 
 void ReportDesignSafeRun()
 {
+    Report("SimulationDesignSafe", "");
     Report("Simulation", "DesignSafe");
 }
 
 void ReportAppUsage(QString appName)
 {
+    Report("Application" + appName, "");
     Report("Application", appName);
 }  
 
 void StartSession()
 {
+    Report("SessionStart", "");
     Report("Session", "Start");
 
 }
 
 void EndSession()
 {
+    Report("SessionEnd", "");
     Report("Session", "End");
 }
 
@@ -66,7 +71,6 @@ void CreateSessionId()
 }
 
 void sendReport();
-
 
 void Report(QString eventCategory, QString eventName)
 {


### PR DESCRIPTION
Make event names more explicit as we can't see the parameter values in google analytics.

The app should now make 2 reports for every event. One with the old style and one with the new style.

I didn't seem to work on my computer but didn't cause any issues either.