### PR TITLE
parseInputOptions return missing

### DIFF
--- a/Common/Utils/SimCenterConfigFile.cpp
+++ b/Common/Utils/SimCenterConfigFile.cpp
@@ -91,6 +91,8 @@ int parseInputOptions(void) {
 
   inputOptions = new QJsonObject(jsonObj);
   parsedInputOptions = true;
+  return 0; // Return int as stated by function header. Void function if desired. Noted on VSCode 2019 in appveyor. We can quiet this error with pragma warning if needed
+  // C:\projects\SimCenter\SimCenterCommon\Common\Utils\SimCenterConfigFile.cpp(94) : error C4716: 'parseInputOptions': must return a value
 }
 
 


### PR DESCRIPTION
Hot-fix for VSCode 2019 build:

C:\projects\SimCenter\SimCenterCommon\Common\Utils\SimCenterConfigFile.cpp(94) : error C4716: 'parseInputOptions': must return a value